### PR TITLE
add docs header for different functions that under same salt module

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ queue.rabbitmq.server
 /etc/rabbitmq/rabbitmq.config
 /etc/rabbitmq/enabled_plugins
 
-%service
+%services
 rabbitmq-server
 
 %description
@@ -89,6 +89,8 @@ Section | Description | Prepend Modifiers | Append Modifiers
 `%directories` | Provide list of directories to be created|`-` | `=`
 `%symlinks`   | Provide list of symlinks to be created using `linkfile->targetfile`||
 `%services`   | Provide list of services that should be running (or not running with minus notation)|`-`|
+`%commands`   | Provide a list of commands that should be executed||
+`%scripts`    | Provide a list of scripts that should be executed||
 `%cronjobs`   |provide a list of cronjobs to be configured. Put these in as normal crontab entries. It will get translated to native `cron.present` state.||
 
 


### PR DESCRIPTION
According to what explained in #18 , I have added the last suggestion mention by @openx-luis. and I have added `section_scripts` which adds support for `cmd.script` in order to test it against different module not just `directories` and it worked as expected.
I have updated the README.md file:
1- There was a typo in the example, `service` changed to `services` so it can work as expected
2- `%scripts` and `%commands` added to the keywords table

I wrote it like this because in scripts i wont need `mod` at all.
```python
for script in self.section_items('scripts'):
    lines.append(TEMPLATES['cmd_script'].render(state=self.statename, script=script[1], title=script[1]))
```